### PR TITLE
Updated uri dependency version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ author: AppTree Software<flutter@apptreesoftware.com>
 homepage: https://github.com/apptreesoftware/flutter_google_map_view
 
 dependencies:
-  uri: "^0.11.1"
+  uri: "^0.11.2"
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
To fix https://github.com/apptreesoftware/flutter_google_map_view/issues/31

```
Running "flutter packages get" in flutter-playbooks...
Package dart_style has no versions that match >=1.0.0 <2.0.0 derived from:
- build_runner 0.7.6 depends on version ^1.0.0
pub get failed (1)
Process finished with exit code 1
```